### PR TITLE
Improve rate limit error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 
 # Endpoints to use, in order of preference. Need to replace <sg-id> with the subgraph name or id defined below
 ENDPOINTS=https://subgraph.satsuma-prod.com/<alchemy subgraphs api key here>/beanstalk-farms/<sg-id>/api|https://gateway-arbitrum.network.thegraph.com/api/<decentralized graph api key here>/subgraphs/id/<sg-id>
-# This is for the status api. Requires custom implementation for each provider.
+# This is for the status api, which requires custom implementation for each provider.
 ENDPOINT_TYPES=alchemy|graph
 
 # Rate limits for each of the above endpoints. Format is rate limit, interval, max burst

--- a/src/services/subgraph-proxy-service.js
+++ b/src/services/subgraph-proxy-service.js
@@ -127,11 +127,11 @@ class SubgraphProxyService {
       // while another endpoint is presumably alive and actively servicing requests.
       if (failedEndpoints.length + unsyncdEndpoints.length === 0) {
         DiscordUtil.sendWebhookMessage(
-          `Rate limit exceeded on all endpoints for '${subgraphName}'. No endpoints attempted to service this request.`
+          `Rate limit exceeded on all endpoints for ${subgraphName}. No endpoints attempted to service this request.`
         );
       } else {
         DiscordUtil.sendWebhookMessage(
-          `Rate limit exceeded on endpoint(s) for '${subgraphName}'. At least one endpoint tried and failed this request.`
+          `Rate limit exceeded on endpoint(s) for ${subgraphName}. At least one endpoint tried and failed this request.`
         );
       }
       throw new RateLimitError(
@@ -156,7 +156,7 @@ class SubgraphProxyService {
         if (fatalError) {
           if (!SubgraphState.endpointHasFatalErrors(endpointIndex, subgraphName)) {
             DiscordUtil.sendWebhookMessage(
-              `A fatal error was encountered for subgraph '${subgraphName}': ${fatalError}`,
+              `A fatal error was encountered for ${subgraphName} e-${endpointIndex}: ${fatalError}`,
               true
             );
             SubgraphState.setEndpointHasFatalErrors(endpointIndex, subgraphName, true);
@@ -164,7 +164,7 @@ class SubgraphProxyService {
         } else {
           hasErrors = false;
           if (SubgraphState.endpointHasFatalErrors(endpointIndex, subgraphName)) {
-            DiscordUtil.sendWebhookMessage(`Subgraph '${subgraphName}': has recovered.`, true);
+            DiscordUtil.sendWebhookMessage(`${subgraphName} e-${endpointIndex} has recovered.`, true);
             SubgraphState.setEndpointHasFatalErrors(endpointIndex, subgraphName, false);
           }
         }
@@ -180,7 +180,7 @@ class SubgraphProxyService {
           SubgraphState.setEndpointHasErrors(failedIndex, subgraphName, true);
         }
         if (!fatalError) {
-          DiscordUtil.sendWebhookMessage(`Failed to retrieve e-${endpointIndex} status for '${subgraphName}'.`, true);
+          console.log(`Failed to retrieve status for ${subgraphName} e-${endpointIndex}.`);
         }
         throw new EndpointError('Subgraph is unable to process this request and may be offline.');
       } else {


### PR DESCRIPTION
Prevents performing the status check on a failed call when at least one endpoint was skipped entirely. This is preferable since in this case the fully utilized endpoint is likely operable, while the one that actually got attempted might not be