### PR TITLE
Improved endpoint routing 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1017 @@
+{
+  "name": "subgraph-proxy",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@types/jest": "^29.5.12"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.24.7",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.24.7",
+        "chalk": "^2.4.2",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.2.tgz",
+      "integrity": "sha512-acJsPTEqYqulZS/Yp/S3GgeE6GZ0qYODUR8aVr/DkhHQ8l9nd4j5x1/ZJy9/gHrRlFMqkO6i0I3E27Alu4jjPg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.24.7",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.24.7",
+        "chalk": "^2.4.2",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^29.6.3"
+      }
+    },
+    "@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "requires": {
+        "@sinclair/typebox": "^0.27.8"
+      }
+    },
+    "@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "requires": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      }
+    },
+    "@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "29.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+      "dev": true,
+      "requires": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "@types/node": {
+      "version": "22.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.2.tgz",
+      "integrity": "sha512-acJsPTEqYqulZS/Yp/S3GgeE6GZ0qYODUR8aVr/DkhHQ8l9nd4j5x1/ZJy9/gHrRlFMqkO6i0I3E27Alu4jjPg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.1.1"
+      }
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true
+    },
+    "expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "requires": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      }
+    },
+    "fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      }
+    },
+    "jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true
+    },
+    "jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      }
+    },
+    "jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      }
+    },
+    "jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      }
+    },
+    "picocolors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "requires": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        }
+      }
+    },
+    "react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
+    },
+    "stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "@types/jest": "^29.5.12"
+  }
+}

--- a/proxy-api/.env.example
+++ b/proxy-api/.env.example
@@ -27,6 +27,6 @@ DISCORD_NOTIFICATION_PREFIX=string
 NODE_ENV=(prod|dev|local|local-docker)
 
 # Enables periodic status checks
-ENABLED_CRON_JOBS=status
+ENABLED_CRON_JOBS=status,reInitGraphState
 # Avoids status check if utilization exceeds this amount
 STATUS_CHECK_MAX_UTILIZATION=0.2

--- a/proxy-api/package-lock.json
+++ b/proxy-api/package-lock.json
@@ -21,7 +21,6 @@
         "node-cron": "^3.0.3"
       },
       "devDependencies": {
-        "@types/jest": "^29.5.12",
         "jest": "^29.7.0",
         "prettier": "^3.3.3"
       }
@@ -1373,16 +1372,6 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@types/jest": {
-      "version": "29.5.12",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
-      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
-      "dev": true,
-      "dependencies": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -6674,16 +6663,6 @@
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "@types/jest": {
-      "version": "29.5.12",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
-      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
-      "dev": true,
-      "requires": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
       }
     },
     "@types/node": {

--- a/proxy-api/package.json
+++ b/proxy-api/package.json
@@ -33,7 +33,6 @@
     "node-cron": "^3.0.3"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.12",
     "jest": "^29.7.0",
     "prettier": "^3.3.3"
   }

--- a/proxy-api/src/app.js
+++ b/proxy-api/src/app.js
@@ -12,7 +12,7 @@ async function appStartup() {
   // Activate whichever cron jobs are configured, if any
   activateJobs(EnvUtil.getEnabledCronJobs());
 
-  await InitService.initAllSubgraphStates();
+  await InitService.initAllStates();
 
   const app = new Koa();
 

--- a/proxy-api/src/scheduled/cron-schedule.js
+++ b/proxy-api/src/scheduled/cron-schedule.js
@@ -1,12 +1,17 @@
 const cron = require('node-cron');
 const DiscordUtil = require('../utils/discord');
 const SubgraphStatusService = require('../services/subgraph-status-service');
+const GraphStateTask = require('./tasks/graph-state');
 
 // All cron jobs which could be activated are configured here
 const ALL_JOBS = {
   status: {
     cron: '* * * * *',
     function: SubgraphStatusService.checkAll.bind(SubgraphStatusService)
+  },
+  reInitGraphState: {
+    cron: '0/30 * * * *',
+    function: GraphStateTask.updateGraphEndpointStates.bind(GraphStateTask)
   }
 };
 

--- a/proxy-api/src/scheduled/cron-schedule.js
+++ b/proxy-api/src/scheduled/cron-schedule.js
@@ -2,16 +2,17 @@ const cron = require('node-cron');
 const DiscordUtil = require('../utils/discord');
 const SubgraphStatusService = require('../services/subgraph-status-service');
 const GraphStateTask = require('./tasks/graph-state');
+const StatusTask = require('./tasks/status');
 
 // All cron jobs which could be activated are configured here
 const ALL_JOBS = {
   status: {
     cron: '* * * * *',
-    function: SubgraphStatusService.checkAll.bind(SubgraphStatusService)
+    function: StatusTask.checkAll
   },
   reInitGraphState: {
     cron: '0/30 * * * *',
-    function: GraphStateTask.updateGraphEndpointStates.bind(GraphStateTask)
+    function: GraphStateTask.updateGraphEndpointStates
   }
 };
 

--- a/proxy-api/src/scheduled/tasks/graph-state.js
+++ b/proxy-api/src/scheduled/tasks/graph-state.js
@@ -1,0 +1,15 @@
+const InitService = require('../../services/init-service');
+const EnvUtil = require('../../utils/env');
+
+class GraphStateTask {
+  // Graph network subgraphs need to be re-initialized periodically since old versions persist and
+  // would still be used by the status check if the deployment hash does not get updated.
+  static async updateGraphEndpointStates() {
+    const graphEndpointIndex = EnvUtil.getEndpointTypes().indexOf('graph');
+    if (graphEndpointIndex !== -1) {
+      await InitService.initEndpointStates(graphEndpointIndex);
+    }
+  }
+}
+
+module.exports = GraphStateTask;

--- a/proxy-api/src/scheduled/tasks/status.js
+++ b/proxy-api/src/scheduled/tasks/status.js
@@ -1,0 +1,24 @@
+const SubgraphStatusService = require('../../services/subgraph-status-service');
+const EnvUtil = require('../../utils/env');
+const BottleneckLimiters = require('../../utils/load/bottleneck-limiters');
+
+class StatusTask {
+  // Perform an error check if utilization is low. There is no need to do the check when
+  // utilization is high, since regular api requests can perform the check also.
+  static async checkAll() {
+    for (const subgraphName of EnvUtil.getEnabledSubgraphs()) {
+      for (const endpointIndex of EnvUtil.endpointsForSubgraph(subgraphName)) {
+        const utilization = await BottleneckLimiters.getUtilization(endpointIndex);
+        if (utilization <= EnvUtil.getStatusCheckMaxUtilization()) {
+          try {
+            await SubgraphStatusService.checkFatalError(endpointIndex, subgraphName);
+          } catch (e) {
+            console.log(`Failed to retrieve status for ${subgraphName} e-${endpointIndex}.`);
+          }
+        }
+      }
+    }
+  }
+}
+
+module.exports = StatusTask;

--- a/proxy-api/src/services/init-service.js
+++ b/proxy-api/src/services/init-service.js
@@ -4,24 +4,44 @@ const GraphqlQueryUtil = require('../utils/graph-query');
 const SubgraphState = require('../utils/state/subgraph');
 
 class InitService {
-  static async initAllSubgraphStates() {
+  // Initializes all states
+  static async initAllStates() {
     const promiseGenerators = [];
     for (const subgraphName of EnvUtil.getEnabledSubgraphs()) {
-      for (const endpointIndex of EnvUtil.endpointsForSubgraph(subgraphName)) {
-        promiseGenerators.push(async () => {
-          try {
-            const client = await SubgraphClients.makeCallableClient(endpointIndex, subgraphName);
-            const metaAndVersion = await client(`{${GraphqlQueryUtil.METADATA_QUERY}}`);
-            SubgraphState.updateStatesWithResult(endpointIndex, subgraphName, metaAndVersion);
-            console.log(`Initialized e-${endpointIndex} for ${subgraphName}.`);
-          } catch (e) {
-            console.log(`Failed to initialize e-${endpointIndex} for ${subgraphName}.`);
-            SubgraphState.setEndpointHasErrors(endpointIndex, subgraphName, true);
-          }
-        });
-      }
+      promiseGenerators.push(() => this.initSubgraphStates(subgraphName));
     }
     await Promise.all(promiseGenerators.map((p) => p()));
+  }
+
+  // Initializes states by subgraph
+  static async initSubgraphStates(subgraphName) {
+    const promiseGenerators = [];
+    for (const endpointIndex of EnvUtil.endpointsForSubgraph(subgraphName)) {
+      promiseGenerators.push(() => this.initState(endpointIndex, subgraphName));
+    }
+    await Promise.all(promiseGenerators.map((p) => p()));
+  }
+
+  // Initializes states by endpoint
+  static async initEndpointStates(endpointIndex) {
+    const promiseGenerators = [];
+    for (const subgraphName of EnvUtil.subgraphsForEndpoint(endpointIndex)) {
+      promiseGenerators.push(() => this.initState(endpointIndex, subgraphName));
+    }
+    await Promise.all(promiseGenerators.map((p) => p()));
+  }
+
+  // Initialize the state for the given endpoint/subgraph pair
+  static async initState(endpointIndex, subgraphName) {
+    try {
+      const client = await SubgraphClients.makeCallableClient(endpointIndex, subgraphName);
+      const metaAndVersion = await client(`{${GraphqlQueryUtil.METADATA_QUERY}}`);
+      SubgraphState.updateStatesWithResult(endpointIndex, subgraphName, metaAndVersion);
+      console.log(`Initialized e-${endpointIndex} for ${subgraphName}.`);
+    } catch (e) {
+      console.log(`Failed to initialize e-${endpointIndex} for ${subgraphName}.`);
+      SubgraphState.setEndpointHasErrors(endpointIndex, subgraphName, true);
+    }
   }
 }
 

--- a/proxy-api/src/services/init-service.js
+++ b/proxy-api/src/services/init-service.js
@@ -37,6 +37,7 @@ class InitService {
       const client = await SubgraphClients.makeCallableClient(endpointIndex, subgraphName);
       const metaAndVersion = await client(`{${GraphqlQueryUtil.METADATA_QUERY}}`);
       SubgraphState.updateStatesWithResult(endpointIndex, subgraphName, metaAndVersion);
+      SubgraphState.setLastEndpointSelectedTimestamp(endpointIndex, subgraphName);
       console.log(`Initialized e-${endpointIndex} for ${subgraphName}.`);
     } catch (e) {
       console.log(`Failed to initialize e-${endpointIndex} for ${subgraphName}.`);

--- a/proxy-api/src/services/subgraph-status-service.js
+++ b/proxy-api/src/services/subgraph-status-service.js
@@ -41,23 +41,6 @@ class SubgraphStatusService {
     return fatalError;
   }
 
-  // Perform an error check if utilization is low. There is no need to do the check when
-  // utilization is high, since regular api requests perform the check also.
-  static async checkAll() {
-    for (const subgraphName of EnvUtil.getEnabledSubgraphs()) {
-      for (const endpointIndex of EnvUtil.endpointsForSubgraph(subgraphName)) {
-        const utilization = await BottleneckLimiters.getUtilization(endpointIndex);
-        if (utilization <= EnvUtil.getStatusCheckMaxUtilization()) {
-          try {
-            await this.checkFatalError(endpointIndex, subgraphName);
-          } catch (e) {
-            console.log(`Failed to retrieve status for ${subgraphName} e-${endpointIndex}.`);
-          }
-        }
-      }
-    }
-  }
-
   static async _getAlchemyStatus(endpointIndex, subgraphName) {
     const statusUrl = EnvUtil.underlyingUrl(endpointIndex, subgraphName).replace('/api', '/status');
     const status = await BottleneckLimiters.schedule(endpointIndex, async () => await axios.post(statusUrl));

--- a/proxy-api/src/utils/env.js
+++ b/proxy-api/src/utils/env.js
@@ -60,6 +60,16 @@ class EnvUtil {
     return validIndices;
   }
 
+  static subgraphsForEndpoint(endpointIndex) {
+    const subgraphNames = [];
+    for (let i = 0; i < ENDPOINT_SG_IDS[endpointIndex].length; ++i) {
+      if (ENDPOINT_SG_IDS[endpointIndex][i]?.trim()) {
+        subgraphNames.push(ENABLED_SUBGRAPHS[i]);
+      }
+    }
+    return subgraphNames;
+  }
+
   // Getters for actual env values
   static getEndpoints() {
     return ENDPOINTS;

--- a/proxy-api/src/utils/load/endpoint-balance.js
+++ b/proxy-api/src/utils/load/endpoint-balance.js
@@ -113,9 +113,9 @@ class EndpointBalanceUtil {
       };
       options.sort(sortLogic);
     }
-    for (let i = 1; i < options.length; ++i) {
+    for (let i = 0; i < options.length; ++i) {
       if (
-        // No need to check utilization here - if there is no recent response and no errors, it cant be over utilized.
+        // No need to check utilization - if there is no recent response and no errors, it cant be over utilized.
         new Date() - SubgraphState.getLastEndpointUsageTimestamp(options[i], subgraphName) > RECENT_RESULT_MS &&
         !SubgraphState.endpointHasFatalErrors(options[i], subgraphName) &&
         !SubgraphState.isRecentlyHavingError(options[i], subgraphName) &&
@@ -140,7 +140,6 @@ class EndpointBalanceUtil {
   // A "troublesome endpoint" is defined as an endpoint which is known in the last minute to: (1) have errors,
   // (2) be out of sync/singificantly behind in indexing, or (3) not running the latest subgraph version
   static async _getTroublesomeEndpoints(endpointsIndices, subgraphName) {
-    const now = new Date();
     const troublesomeEndpoints = [];
     for (const endpointIndex of endpointsIndices) {
       // Dont consider a subgraph troublesome if it hasnt been queried yet

--- a/proxy-api/src/utils/load/endpoint-balance.js
+++ b/proxy-api/src/utils/load/endpoint-balance.js
@@ -148,15 +148,12 @@ class EndpointBalanceUtil {
   static async _getTroublesomeEndpoints(endpointsIndices, subgraphName) {
     const troublesomeEndpoints = [];
     for (const endpointIndex of endpointsIndices) {
-      // Dont consider a subgraph troublesome if it hasnt been queried yet
-      if (SubgraphState.getEndpointDeployment(endpointIndex, subgraphName)) {
-        if (
-          SubgraphState.isRecentlyHavingError(endpointIndex, subgraphName) ||
-          (await SubgraphState.isRecentlyOutOfSync(endpointIndex, subgraphName)) ||
-          (await SubgraphState.isRecentlyStaleVersion(endpointIndex, subgraphName))
-        ) {
-          troublesomeEndpoints.push(endpointIndex);
-        }
+      if (
+        SubgraphState.isRecentlyHavingError(endpointIndex, subgraphName) ||
+        (await SubgraphState.isRecentlyOutOfSync(endpointIndex, subgraphName)) ||
+        (await SubgraphState.isRecentlyStaleVersion(endpointIndex, subgraphName))
+      ) {
+        troublesomeEndpoints.push(endpointIndex);
       }
     }
     return troublesomeEndpoints;

--- a/proxy-api/src/utils/load/endpoint-balance.js
+++ b/proxy-api/src/utils/load/endpoint-balance.js
@@ -21,6 +21,11 @@ class EndpointBalanceUtil {
    * iii. If (i) and (ii) were not satisfied, do not query the same endpoint again in the next attempt.
    *  c. If both have a result within the last second, prefer one having a later block
    *  d. Prefer according to utilization
+   *
+   * 4c. consider: if any do not have a result within the last second, and have no known errors, try that one
+   * this only works if the error checking is sound
+   *  - init should contain the required info
+   *
    * @param {string} subgraphName
    * @param {number[]} blacklist - none of these endpoints should be returned.
    * @param {number[]} history - sequence of endpoints which have been chosen and queried to serve this request.

--- a/proxy-api/src/utils/logging.js
+++ b/proxy-api/src/utils/logging.js
@@ -4,7 +4,7 @@ class LoggingUtil {
   // Used to determine how much whitespace should pad the start of the subgraph name
   static longestEncounteredName = 0;
 
-  static async logSuccessfulProxy(subgraphName, startTime, startUtilization, requestHistory) {
+  static async logSuccessfulProxy(subgraphName, startTime, startUtilization, requestHistory, blacklist) {
     console.log(
       await this._formatLog(
         '[success]',
@@ -12,20 +12,31 @@ class LoggingUtil {
         startTime,
         startUtilization,
         requestHistory,
+        blacklist,
         requestHistory[requestHistory.length - 1]
       )
     );
   }
 
-  static async logFailedProxy(subgraphName, startTime, startUtilization, requestHistory) {
-    console.log(await this._formatLog('<failure>', subgraphName, startTime, startUtilization, requestHistory));
+  static async logFailedProxy(subgraphName, startTime, startUtilization, requestHistory, blacklist) {
+    console.log(
+      await this._formatLog('<failure>', subgraphName, startTime, startUtilization, blacklist, requestHistory)
+    );
   }
 
   // Samples:
   // 2024-08-24T01:16:58.197Z [success]: beanstalk_proxy to e-0 after  156ms | Steps: 0 | Load: e-0:  0%, e-1:0%
   // 2024-08-24T01:16:50.403Z [success]: bean----------- to e-0 after  157ms | Steps: 0 | Load: e-0: 33%, e-1:0%
   // 2024-08-24T01:17:41.354Z <failure>: basin---------- ------ after  141ms | Steps: 0 | Load: e-0: 33%
-  static async _formatLog(type, subgraphName, startTime, startUtilization, requestHistory, usedEndpoint = undefined) {
+  static async _formatLog(
+    type,
+    subgraphName,
+    startTime,
+    startUtilization,
+    requestHistory,
+    blacklist,
+    usedEndpoint = undefined
+  ) {
     if (subgraphName.length > this.longestEncounteredName) {
       this.longestEncounteredName = subgraphName.length;
     }
@@ -36,7 +47,7 @@ class LoggingUtil {
       `${subgraphName.padEnd(this.longestEncounteredName, '-')} ${`${toEndpoint}after ${timeElapsed}`.padStart(19, '-')}`.padEnd(
         40
       );
-    const steps = `Steps: ${requestHistory.join(',')}`.padEnd(20);
+    const steps = (`Steps[${blacklist.join(',')}]`.padEnd(10) + `: ${requestHistory.join(',')}`).padEnd(25);
     const utilization = `Load: ${this._formatUtilizationString(startUtilization)}`;
     return `${new Date().toISOString()} ${type}: ${subgraphAndTime} | ${steps} | ${utilization}`;
   }

--- a/proxy-api/src/utils/state/subgraph.js
+++ b/proxy-api/src/utils/state/subgraph.js
@@ -155,11 +155,7 @@ class SubgraphState {
   static async getLatestActiveVersion(subgraphName) {
     let versions = [];
     for (const i of EnvUtil.endpointsForSubgraph(subgraphName)) {
-      if (
-        this.getEndpointDeployment(i, subgraphName) &&
-        (await this.isInSync(i, subgraphName)) &&
-        !this.endpointHasErrors(i, subgraphName)
-      ) {
+      if ((await this.isInSync(i, subgraphName)) && !this.endpointHasErrors(i, subgraphName)) {
         versions.push(this._endpointVersion[`${i}-${subgraphName}`]);
       }
     }
@@ -179,7 +175,7 @@ class SubgraphState {
   // Not a perfect assumption - the endpoint is considered in sync if it is within 50 blocks of the chain head.
   static async isInSync(endpointIndex, subgraphName) {
     const chain = this.getEndpointChain(endpointIndex, subgraphName);
-    return this.getEndpointBlock(endpointIndex, subgraphName) + 50 > (await ChainState.getChainHead(chain));
+    return chain && this.getEndpointBlock(endpointIndex, subgraphName) + 50 > (await ChainState.getChainHead(chain));
   }
 
   static async isStaleVersion(endpointIndex, subgraphName) {

--- a/proxy-api/src/utils/state/subgraph.js
+++ b/proxy-api/src/utils/state/subgraph.js
@@ -21,8 +21,7 @@ class SubgraphState {
   static _endpointHasErrors = {};
   // Only true when the subgraph implementation's status endpoint indicates a fatal error.
   static _endpointHasFatalErrors = {};
-  // Timestamps of notable events on this endpoint: errors, out of sync, and stale version.
-  // The timestamp is updated any time one of these is encountered.
+  // Timestamps of notable events on this endpoint.
   static _endpointTimestamps = {};
 
   static getLatestSubgraphErrorCheck(subgraphName) {
@@ -96,8 +95,11 @@ class SubgraphState {
     this.setEndpointHasErrors(endpointIndex, subgraphName, value);
   }
 
-  static getLastEndpointUsageTimestamp(endpointIndex, subgraphName) {
-    return this._endpointTimestamps[`${endpointIndex}-${subgraphName}`]?.usage;
+  static getLastEndpointSelectedTimestamp(endpointIndex, subgraphName) {
+    return this._endpointTimestamps[`${endpointIndex}-${subgraphName}`]?.selected;
+  }
+  static getLastEndpointResultTimestamp(endpointIndex, subgraphName) {
+    return this._endpointTimestamps[`${endpointIndex}-${subgraphName}`]?.result;
   }
   static getLastEndpointErrorTimestamp(endpointIndex, subgraphName) {
     return this._endpointTimestamps[`${endpointIndex}-${subgraphName}`]?.error;
@@ -109,8 +111,11 @@ class SubgraphState {
     return this._endpointTimestamps[`${endpointIndex}-${subgraphName}`]?.staleVersion;
   }
 
-  static setLastEndpointUsageTimestamp(endpointIndex, subgraphName) {
-    this.setEndpointTimestamp(endpointIndex, subgraphName, 'usage');
+  static setLastEndpointSelectedTimestamp(endpointIndex, subgraphName) {
+    this.setEndpointTimestamp(endpointIndex, subgraphName, 'selected');
+  }
+  static setLastEndpointResultTimestamp(endpointIndex, subgraphName) {
+    this.setEndpointTimestamp(endpointIndex, subgraphName, 'result');
   }
   static setLastEndpointErrorTimestamp(endpointIndex, subgraphName) {
     this.setEndpointTimestamp(endpointIndex, subgraphName, 'error');
@@ -129,7 +134,7 @@ class SubgraphState {
 
   // Updates persistent states upon a successful request
   static async updateStatesWithResult(endpointIndex, subgraphName, queryResult) {
-    SubgraphState.setLastEndpointUsageTimestamp(endpointIndex, subgraphName);
+    SubgraphState.setLastEndpointResultTimestamp(endpointIndex, subgraphName);
     SubgraphState.setEndpointDeployment(endpointIndex, subgraphName, queryResult._meta.deployment);
     SubgraphState.setEndpointChain(endpointIndex, subgraphName, queryResult.version.chain);
     SubgraphState.setEndpointBlock(endpointIndex, subgraphName, queryResult._meta.block.number);

--- a/proxy-api/src/utils/state/subgraph.js
+++ b/proxy-api/src/utils/state/subgraph.js
@@ -190,6 +190,25 @@ class SubgraphState {
     }
     return true;
   }
+
+  static isRecentlyHavingError(endpointIndex, subgraphName, window = 60 * 1000) {
+    return (
+      SubgraphState.endpointHasErrors(endpointIndex, subgraphName) &&
+      new Date() - SubgraphState.getLastEndpointErrorTimestamp(endpointIndex, subgraphName) < window
+    );
+  }
+  static async isRecentlyOutOfSync(endpointIndex, subgraphName, window = 60 * 1000) {
+    return (
+      !(await SubgraphState.isInSync(endpointIndex, subgraphName)) &&
+      new Date() - SubgraphState.getLastEndpointOutOfSyncTimestamp(endpointIndex, subgraphName) < window
+    );
+  }
+  static async isRecentlyStaleVersion(endpointIndex, subgraphName, window = 60 * 1000) {
+    return (
+      (await SubgraphState.isStaleVersion(endpointIndex, subgraphName)) &&
+      new Date() - SubgraphState.getLastEndpointStaleVersionTimestamp(endpointIndex, subgraphName) < window
+    );
+  }
 }
 
 module.exports = SubgraphState;

--- a/proxy-api/src/utils/state/subgraph.js
+++ b/proxy-api/src/utils/state/subgraph.js
@@ -131,9 +131,9 @@ class SubgraphState {
   static async updateStatesWithResult(endpointIndex, subgraphName, queryResult) {
     SubgraphState.setLastEndpointUsageTimestamp(endpointIndex, subgraphName);
     SubgraphState.setEndpointDeployment(endpointIndex, subgraphName, queryResult._meta.deployment);
-    SubgraphState.setEndpointVersion(endpointIndex, subgraphName, queryResult.version.versionNumber);
     SubgraphState.setEndpointChain(endpointIndex, subgraphName, queryResult.version.chain);
     SubgraphState.setEndpointBlock(endpointIndex, subgraphName, queryResult._meta.block.number);
+    SubgraphState.setEndpointVersion(endpointIndex, subgraphName, queryResult.version.versionNumber);
     SubgraphState.setEndpointHasErrors(endpointIndex, subgraphName, false);
   }
 
@@ -150,7 +150,11 @@ class SubgraphState {
   static async getLatestActiveVersion(subgraphName) {
     let versions = [];
     for (const i of EnvUtil.endpointsForSubgraph(subgraphName)) {
-      if ((await this.isInSync(i, subgraphName)) && !this.endpointHasErrors(i, subgraphName)) {
+      if (
+        this.getEndpointDeployment(i, subgraphName) &&
+        (await this.isInSync(i, subgraphName)) &&
+        !this.endpointHasErrors(i, subgraphName)
+      ) {
         versions.push(this._endpointVersion[`${i}-${subgraphName}`]);
       }
     }

--- a/proxy-api/test/balancer.test.js
+++ b/proxy-api/test/balancer.test.js
@@ -171,7 +171,7 @@ describe('Endpoint Balancer', () => {
       jest.spyOn(SubgraphState, 'getEndpointBlock').mockImplementation((endpointIndex, _) => {
         return endpointIndex === 0 ? 499 : 500;
       });
-      jest.spyOn(SubgraphState, 'getLastEndpointUsageTimestamp').mockReturnValue(mockTimeNow);
+      jest.spyOn(SubgraphState, 'getLastEndpointResultTimestamp').mockReturnValue(mockTimeNow);
       expect(await EndpointBalanceUtil.chooseEndpoint('bean')).toEqual(1);
       expect(await EndpointBalanceUtil.chooseEndpoint('bean', [1])).toEqual(0);
 
@@ -194,7 +194,7 @@ describe('Endpoint Balancer', () => {
         jest.spyOn(BottleneckLimiters, 'getUtilization').mockImplementation((endpointIndex) => {
           return endpointIndex === 0 ? 0.1 : 0;
         });
-        jest.spyOn(SubgraphState, 'getLastEndpointUsageTimestamp').mockImplementation((endpointIndex, _) => {
+        jest.spyOn(SubgraphState, 'getLastEndpointResultTimestamp').mockImplementation((endpointIndex, _) => {
           return endpointIndex === 0 ? mockTimeNow : mockTimePrev;
         });
       });
@@ -288,7 +288,7 @@ describe('Endpoint Balancer', () => {
       expect(await EndpointBalanceUtil.chooseEndpoint('bean', [], [0])).toEqual(1);
       expect(await EndpointBalanceUtil.chooseEndpoint('bean', [], [1], 500)).toEqual(1);
       // Both having recent results
-      jest.spyOn(SubgraphState, 'getLastEndpointUsageTimestamp').mockReturnValue(mockTimeNow);
+      jest.spyOn(SubgraphState, 'getLastEndpointResultTimestamp').mockReturnValue(mockTimeNow);
       expect(await EndpointBalanceUtil.chooseEndpoint('bean')).toEqual(1);
     });
   });

--- a/proxy-api/test/mock-responses/beanFarBehind.json
+++ b/proxy-api/test/mock-responses/beanFarBehind.json
@@ -1,0 +1,30 @@
+{
+  "version": {
+    "subgraphName": "bean",
+    "versionNumber": "2.3.1",
+    "chain": "ethereum"
+  },
+  "beanCrosses": [
+    {
+      "id": "0"
+    },
+    {
+      "id": "1"
+    },
+    {
+      "id": "10"
+    },
+    {
+      "id": "100"
+    },
+    {
+      "id": "1000"
+    }
+  ],
+  "_meta": {
+    "block": {
+      "number": 20580043
+    },
+    "deployment": "QmXXZrhjqb4ygSWVgkPYBWJ7AzY4nKEUqiN5jnDopWBSCD"
+  }
+}

--- a/proxy-api/test/mock-responses/beanOldVersion.json
+++ b/proxy-api/test/mock-responses/beanOldVersion.json
@@ -1,0 +1,30 @@
+{
+  "version": {
+    "subgraphName": "bean",
+    "versionNumber": "2.3.0",
+    "chain": "ethereum"
+  },
+  "beanCrosses": [
+    {
+      "id": "0"
+    },
+    {
+      "id": "1"
+    },
+    {
+      "id": "10"
+    },
+    {
+      "id": "100"
+    },
+    {
+      "id": "1000"
+    }
+  ],
+  "_meta": {
+    "block": {
+      "number": 20581045
+    },
+    "deployment": "QmXXZrhjqb4ygSWVgkPYBWJ7AzY4nKEUqiN5jnDopWBSCD"
+  }
+}

--- a/proxy-api/test/proxy-internals.test.js
+++ b/proxy-api/test/proxy-internals.test.js
@@ -10,6 +10,7 @@ const { captureAndReturn } = require('./utils/capture-args');
 const beanResponse = require('./mock-responses/bean.json');
 const beanBehindResponse = require('./mock-responses/beanBehind.json');
 const beanNewDeploymentResponse = require('./mock-responses/beanNewDeployment.json');
+const beanOldVersionResponse = require('./mock-responses/beanOldVersion.json');
 const RateLimitError = require('../src/error/rate-limit-error');
 const EnvUtil = require('../src/utils/env');
 const SubgraphStatusService = require('../src/services/subgraph-status-service');
@@ -24,6 +25,10 @@ describe('Subgraph Proxy - Core', () => {
   beforeEach(() => {
     // Clears call history (NOT implementations)
     jest.clearAllMocks();
+    // Reset static members between test
+    for (const property of Object.keys(SubgraphState)) {
+      SubgraphState[property] = {};
+    }
   });
 
   beforeAll(() => {
@@ -136,6 +141,30 @@ describe('Subgraph Proxy - Core', () => {
       expect(EndpointBalanceUtil.chooseEndpoint).toHaveBeenCalledTimes(3);
       expect(endpointArgCapture[1]).toEqual(['bean', [0], [0], null]);
       expect(endpointArgCapture[2]).toEqual(['bean', [0, 1], [0, 1], null]);
+    });
+    test('Old subgraph version is not accepted unless newer fails', async () => {
+      jest
+        .spyOn(EndpointBalanceUtil, 'chooseEndpoint')
+        .mockReset()
+        .mockImplementationOnce((...args) => captureAndReturn(endpointArgCapture, 0, ...args))
+        .mockImplementationOnce((...args) => captureAndReturn(endpointArgCapture, 1, ...args))
+        .mockImplementationOnce((...args) => captureAndReturn(endpointArgCapture, 0, ...args));
+      jest
+        .spyOn(SubgraphClients, 'makeCallableClient')
+        .mockResolvedValueOnce(async () => beanOldVersionResponse)
+        .mockImplementationOnce(async () => async () => {
+          throw new Error('Generic failure reason');
+        })
+        .mockResolvedValueOnce(async () => beanOldVersionResponse);
+
+      // Old version will be served on endpoint 0 as 2.3.0
+      SubgraphState.setEndpointBlock(1, 'bean', responseBlock);
+      SubgraphState.setEndpointVersion(1, 'bean', '2.3.1');
+
+      await expect(SubgraphProxyService._getQueryResult('bean', 'graphql query')).resolves.not.toThrow();
+      expect(EndpointBalanceUtil.chooseEndpoint).toHaveBeenCalledTimes(3);
+      expect(endpointArgCapture[1]).toEqual(['bean', [0], [0], null]);
+      expect(endpointArgCapture[2]).toEqual(['bean', [1], [0, 1], null]);
     });
     test('User explicitly queries far past block', async () => {
       jest.spyOn(SubgraphClients, 'makeCallableClient').mockImplementationOnce(async () => async () => {

--- a/proxy-api/test/proxy-internals.test.js
+++ b/proxy-api/test/proxy-internals.test.js
@@ -67,6 +67,7 @@ describe('Subgraph Proxy - Core', () => {
         .mockImplementationOnce((...args) => captureAndReturn(endpointArgCapture, -1, ...args))
         .mockImplementationOnce((...args) => captureAndReturn(endpointArgCapture, 0, ...args));
       jest.spyOn(SubgraphState, 'getLatestSubgraphErrorCheck').mockReturnValue(undefined);
+      jest.spyOn(SubgraphState, 'getEndpointChain').mockReturnValue('ethereum');
     });
 
     test('Initial endpoint succeeds', async () => {
@@ -174,7 +175,7 @@ describe('Subgraph Proxy - Core', () => {
         jest
           .spyOn(SubgraphClients, 'makeCallableClient')
           .mockResolvedValueOnce(async () => beanOldVersionResponse)
-          .mockResolvedValueOnce(async () => beanFarBehind)
+          .mockResolvedValueOnce(async () => beanFarBehindResponse)
           .mockResolvedValueOnce(async () => beanOldVersionResponse);
 
         await expect(SubgraphProxyService._getQueryResult('bean', 'graphql query')).resolves.not.toThrow();

--- a/proxy-api/test/state.test.js
+++ b/proxy-api/test/state.test.js
@@ -10,6 +10,7 @@ describe('State: Derived functions', () => {
     jest.resetAllMocks();
     jest.spyOn(EnvUtil, 'endpointsForSubgraph').mockReturnValue([0, 1]);
     jest.spyOn(ChainState, 'getChainHead').mockResolvedValue(500);
+    jest.spyOn(SubgraphState, 'getEndpointChain').mockResolvedValue('ethereum');
     // Reset static members between test
     for (const property of Object.keys(SubgraphState)) {
       SubgraphState[property] = {};

--- a/proxy-api/test/state.test.js
+++ b/proxy-api/test/state.test.js
@@ -18,11 +18,11 @@ describe('State: Derived functions', () => {
     }
   });
 
-  test('Gets aggregate latest subgraph version', () => {
-    SubgraphState.setEndpointVersion(0, 'bean', '2.1.0');
-    SubgraphState.setEndpointVersion(0, 'beanstalk', '2.2.5');
-    SubgraphState.setEndpointVersion(1, 'bean', '2.1.2');
-    SubgraphState.setEndpointVersion(1, 'beanstalk', '1.2.4');
+  test('Gets aggregate latest subgraph version', async () => {
+    await SubgraphState.setEndpointVersion(0, 'bean', '2.1.0');
+    await SubgraphState.setEndpointVersion(0, 'beanstalk', '2.2.5');
+    await SubgraphState.setEndpointVersion(1, 'bean', '2.1.2');
+    await SubgraphState.setEndpointVersion(1, 'beanstalk', '1.2.4');
 
     expect(SubgraphState.getLatestVersion('bean')).toEqual('2.1.2');
     expect(SubgraphState.getLatestVersion('beanstalk')).toEqual('2.2.5');
@@ -83,9 +83,10 @@ describe('State: Derived functions', () => {
       await SubgraphState.setEndpointBlock(0, 'bean', 15);
       expect(SubgraphState.getLastEndpointOutOfSyncTimestamp(0, 'bean')).toEqual(mockTimeNow);
 
+      jest.spyOn(SubgraphState, 'isInSync').mockResolvedValue(true);
       expect(SubgraphState.getLastEndpointStaleVersionTimestamp(0, 'bean')).toBeUndefined();
-      SubgraphState.setEndpointVersion(1, 'bean', '1.0.0');
-      SubgraphState.setEndpointVersion(0, 'bean', '0.9.5');
+      await SubgraphState.setEndpointVersion(1, 'bean', '1.0.0');
+      await SubgraphState.setEndpointVersion(0, 'bean', '0.9.5');
       expect(SubgraphState.getLastEndpointStaleVersionTimestamp(0, 'bean')).toEqual(mockTimeNow);
     });
   });

--- a/proxy-api/test/state.test.js
+++ b/proxy-api/test/state.test.js
@@ -69,9 +69,9 @@ describe('State: Derived functions', () => {
       expect(SubgraphState.getLastEndpointOutOfSyncTimestamp(0, 'bean')).toEqual(mockTimeFuture);
     });
     test('Endpoint timestamps get set under appropriate circumstances', async () => {
-      expect(SubgraphState.getLastEndpointUsageTimestamp(0, 'bean')).toBeUndefined();
-      SubgraphState.setLastEndpointUsageTimestamp(0, 'bean');
-      expect(SubgraphState.getLastEndpointUsageTimestamp(0, 'bean')).toEqual(mockTimeNow);
+      expect(SubgraphState.getLastEndpointResultTimestamp(0, 'bean')).toBeUndefined();
+      SubgraphState.setLastEndpointResultTimestamp(0, 'bean');
+      expect(SubgraphState.getLastEndpointResultTimestamp(0, 'bean')).toEqual(mockTimeNow);
 
       expect(SubgraphState.getLastEndpointErrorTimestamp(0, 'bean')).toBeUndefined();
       SubgraphState.setEndpointHasErrors(0, 'bean', true);


### PR DESCRIPTION
- Periodically allows a non-preferred underutilized endpoint to be selected. This helps in discovery of which of the subgraphs has indexed a further block
- Responses from old subgraph versions is now allowed only if the latest version has crashed
- Graph subgraphs have their state re initialized every 30 mins to support discovery of new deployments